### PR TITLE
Refactor: Split parsing functions into separate parse/print

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -101,7 +101,18 @@ void parse_ethernet_header(const u_char *packet, packet_t *pkt)
     memcpy(&pkt->eth_hdr.dst_mac, packet, 6);
     memcpy(&pkt->eth_hdr.src_mac, packet + 6, 6);
     memcpy(&pkt->eth_hdr.eth_type, packet + 12, 2);
+}
 
+/*
+Function: void print_ethernet_header(packet_t *pkt)
+Prints contents of packet's ethernet header (first 14 bytes)
+
+Parameters:
+*pkt - packet structure to store values
+
+Returns: void
+*/
+void print_ethernet_header(packet_t *pkt){
     printf("=== Ethernet Header ===\n");
     printf("Destination MAC: %02x:%02x:%02x:%02x:%02x:%02x\n",
         pkt->eth_hdr.dst_mac[0], pkt->eth_hdr.dst_mac[1], pkt->eth_hdr.dst_mac[2],
@@ -125,6 +136,7 @@ Returns: void
 */
 void parse_tcp_header(const u_char *packet, packet_t *pkt, int offset)
 {
+    printf("Offset: %d\n",offset);
     memcpy(&pkt->trans_hdr.tcp_hdr.src_port, packet + offset, 2);
     memcpy(&pkt->trans_hdr.tcp_hdr.dst_port, packet + offset + 2, 2);
     memcpy(&pkt->trans_hdr.tcp_hdr.sequence_num, packet + offset + 4, 4);
@@ -135,6 +147,18 @@ void parse_tcp_header(const u_char *packet, packet_t *pkt, int offset)
     memcpy(&pkt->trans_hdr.tcp_hdr.checksum, packet + offset + 16, 2);
     memcpy(&pkt->trans_hdr.tcp_hdr.urgent_pointer, packet + offset + 18, 2);
     strcpy(pkt->proto, "TCP");
+}
+
+/*
+Function: void print_tcp_header(packet_t *pkt)
+Prints contents of packet's TCP header (20-60 bytes)
+
+Parameters:
+*pkt - packet structure to store values
+
+Returns: void
+*/
+void print_tcp_header(packet_t *pkt){
     printf("\n < ! - - - - - TCP HEADER - - - - - ! >\n");
     printf("SRC PORT: %u\n", ntohs(pkt->trans_hdr.tcp_hdr.src_port));
     printf("DST PORT: %u\n", ntohs(pkt->trans_hdr.tcp_hdr.dst_port));
@@ -181,6 +205,18 @@ void parse_udp_header(const u_char *packet, packet_t *pkt, int offset)
     memcpy(&pkt->trans_hdr.udp_hdr.dst_port, packet + offset + 2, 2);
     memcpy(&pkt->trans_hdr.udp_hdr.len, packet + offset + 4, 2);
     memcpy(&pkt->trans_hdr.udp_hdr.checksum, packet + offset + 6, 2);
+}
+
+/*
+Function: void print_udp_header(packet_t *pkt)
+Prints contents of packet's UDP header (8 bytes)
+
+Parameters:
+*pkt - packet structure to store values
+
+Returns: void
+*/
+void print_udp_header(packet_t *pkt){
     printf("\n < ! - - - - - UDP HEADER - - - - - ! >\n");
     printf("Source Port: %u\n", ntohs(pkt->trans_hdr.udp_hdr.src_port));
     printf("Destination Port: %u\n", ntohs(pkt->trans_hdr.udp_hdr.dst_port));
@@ -205,6 +241,18 @@ void parse_icmp_header(const u_char *packet, packet_t *pkt, int offset)
     memcpy(&pkt->trans_hdr.icmp_hdr.type, packet + offset, 1);
     memcpy(&pkt->trans_hdr.icmp_hdr.code, packet + offset + 1, 1);
     memcpy(&pkt->trans_hdr.icmp_hdr.checksum, packet + offset + 2, 2);
+}
+
+/*
+Function: void print_icmp_header(packet_t *pkt)
+Prints contents of packet's ICMPv6 header (8 bytes)
+
+Parameters:
+*pkt - packet structure to store values
+
+Returns: void
+*/
+void print_icmp_header(packet_t *pkt){
     printf("\n < ! - - - - - ICMP HEADER - - - - - ! >\n");
     printf("Type: %u\n", pkt->trans_hdr.icmp_hdr.type);
     printf("Code: %u\n", pkt->trans_hdr.icmp_hdr.code);
@@ -234,6 +282,19 @@ void parse_arp_header(const u_char *packet, packet_t *pkt, int offset)
     memcpy(&pkt->net_hdr.arp_hdr.spa, packet + offset + 14, 4);
     memcpy(&pkt->net_hdr.arp_hdr.tha, packet + offset + 18, 6);
     memcpy(&pkt->net_hdr.arp_hdr.tpa, packet + offset + 24, 4);
+    strcpy(pkt->proto, "ARP");
+}
+
+/*
+Function: void print_arp_header(packet_t *pkt)
+Prints contents of packet's ARP header (28 bytes)
+
+Parameters:
+*pkt - packet structure to store values
+
+Returns: void
+*/
+void print_arp_header(packet_t *pkt){
     struct in_addr src_addr, dst_addr;
     src_addr.s_addr = pkt->net_hdr.arp_hdr.spa;
     dst_addr.s_addr = pkt->net_hdr.arp_hdr.tpa;
@@ -251,7 +312,6 @@ void parse_arp_header(const u_char *packet, packet_t *pkt, int offset)
         pkt->net_hdr.arp_hdr.tha[0], pkt->net_hdr.arp_hdr.tha[1], pkt->net_hdr.arp_hdr.tha[2],
         pkt->net_hdr.arp_hdr.tha[3], pkt->net_hdr.arp_hdr.tha[4], pkt->net_hdr.arp_hdr.tha[5]);
     printf("\n ARP TARGET IP: %s\n", inet_ntoa(dst_addr));
-    strcpy(pkt->proto, "ARP");
 }
 
 /*
@@ -277,7 +337,18 @@ void parse_ipv4_header(const u_char *packet, packet_t *pkt, int offset)
     memcpy(&pkt->net_hdr.ipv4_hdr.hdr_checksum, packet + offset + 10, 2);
     memcpy(&pkt->net_hdr.ipv4_hdr.src_ip, packet + offset + 12, 4);
     memcpy(&pkt->net_hdr.ipv4_hdr.dst_ip, packet + offset + 16, 4);
+}
 
+/*
+Function: void print_ipv4_header(packet_t *pkt)
+Prints contents of packet's IPv4 header (20-60 bytes)
+
+Parameters:
+*pkt - packet structure to store values
+
+Returns: void
+*/
+void print_ipv4_header(packet_t *pkt){
     struct in_addr src_addr, dst_addr;
     src_addr.s_addr = pkt->net_hdr.ipv4_hdr.src_ip;
     dst_addr.s_addr = pkt->net_hdr.ipv4_hdr.dst_ip;
@@ -313,6 +384,18 @@ void parse_ipv6_header(const u_char *packet, packet_t *pkt, int offset)
     memcpy(&pkt->net_hdr.ipv6_hdr.hop_limit, packet + offset + 7, 1);
     memcpy(&pkt->net_hdr.ipv6_hdr.src_addr, packet + offset + 8, 16);
     memcpy(&pkt->net_hdr.ipv6_hdr.dst_addr, packet + offset + 24, 16);
+}
+
+/*
+Function: void print_ipv6_header(packet_t *pkt)
+Prints contents of packet's IPv6 header (40 bytes)
+
+Parameters:
+*pkt - packet structure to store values
+
+Returns: void
+*/
+void print_ipv6_header(packet_t *pkt){
     char src_ipv6[INET6_ADDRSTRLEN], dst_ipv6[INET6_ADDRSTRLEN];
     inet_ntop(AF_INET6, &pkt->net_hdr.ipv6_hdr.src_addr, src_ipv6, INET6_ADDRSTRLEN);
     inet_ntop(AF_INET6, &pkt->net_hdr.ipv6_hdr.dst_addr, dst_ipv6, INET6_ADDRSTRLEN);
@@ -340,18 +423,21 @@ void packetParser(const u_char *packet, int packet_len, rule_t *rule)
     packet_t pkt; // Create instance of packet
     print_hex_dump(packet, packet_len);
     parse_ethernet_header(packet, &pkt);
+    print_ethernet_header(&pkt);
 
     // Switch statement to select respective protocol
     switch (ntohs(pkt.eth_hdr.eth_type)) {
     case 0x0800: // 0x0800 = IPv4
-
         parse_ipv4_header(packet, &pkt, 14);
+        print_ipv4_header(&pkt);
         break;
     case 0x86DD: // 0x86DD = IPv6
         parse_ipv6_header(packet, &pkt, 14);
+        print_ipv6_header(&pkt);
         break;
     case 0x0806: // 0x0806 = ARP
         parse_arp_header(packet, &pkt, 14);
+        print_arp_header(&pkt);
         break;
     default:
         printf("\nUKNOWN PROTOCOL\n");
@@ -359,17 +445,21 @@ void packetParser(const u_char *packet, int packet_len, rule_t *rule)
 
     // Selects respective protocol given protocol/next header specifiers
     // IPv4 protocol == IPv6 Next header
-    if (pkt.net_hdr.ipv4_hdr.protocol == 6) {
+    if (pkt.net_hdr.ipv4_hdr.protocol == 6 && (ntohs(pkt.eth_hdr.eth_type)) == 0x0800) {
         uint8_t ihl = pkt.net_hdr.ipv4_hdr.version_ihl & 0x0f; // Bit mask to select last 4 bits
         uint8_t offset = ((ihl * 32) / 8) + 14; // Offset for start of TCP header given IPv4 internet header length (IHL)
         parse_tcp_header(packet, &pkt, offset);
-    } else if (pkt.net_hdr.ipv6_hdr.next_hdr == 6) {
+        print_tcp_header(&pkt);
+    } else if (pkt.net_hdr.ipv6_hdr.next_hdr == 6 && (ntohs(pkt.eth_hdr.eth_type)) == 0x86dd) {
         parse_tcp_header(packet, &pkt, 54);
-    } else if (pkt.net_hdr.ipv4_hdr.protocol == 17 || pkt.net_hdr.ipv6_hdr.next_hdr == 17) {
+        print_tcp_header(&pkt);
+    } else if ((pkt.net_hdr.ipv4_hdr.protocol == 17 && (ntohs(pkt.eth_hdr.eth_type)) == 0x0800) || (pkt.net_hdr.ipv6_hdr.next_hdr == 17 && (ntohs(pkt.eth_hdr.eth_type)) == 0x86dd)) {
         int offset = (pkt.net_hdr.ipv4_hdr.protocol == 17) ? 34 : 54; // Select offset based on internet protocol version
         parse_udp_header(packet, &pkt, offset);
-    } else if (pkt.net_hdr.ipv6_hdr.next_hdr == 58) {
-        parse_icmp_header(packet, &pkt, 54); // ICMPv6
+        print_udp_header(&pkt);
+    } else if (pkt.net_hdr.ipv6_hdr.next_hdr == 58) { // ICMPv6
+        parse_icmp_header(packet, &pkt, 54); 
+        print_icmp_header(&pkt);
     }
     rule_check(rule, pkt);
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -33,48 +33,6 @@ Returns: void
 void parse_hex_input(char *input, int len, rule_t *rule);
 
 /*
-Function: void print_hex_dump(const u_char *packet, int packet_len)
-Prints the raw hex stream of captured packet
-
-Parameters:
-*packet - raw u_char bytes of packet data
-packet_len - length of packet in bytes
-
-Returns: void
-*/
-void print_hex_dump(const u_char *packet, int packet_len);
-
-/*
-Function: void parse_ethernet_header(const u_char *packet, packet_t *pkt)
-Parses packet and sets packet fields to values corresponding to ethernet header
-
-Parameters:
-*packet - raw u_char bytes of packet data
-*pkt - packet structure to store values
-
-Returns: void
-*/
-void parse_ethernet_header(const u_char *packet, packet_t *pkt);
-
-/*
-Function: void parse_*_header(const u_char *packet, packet_t *pkt, int offset)
-Parses packet and sets packet fields to values corresponding to each header
-
-Parameters:
-*packet - raw u_char bytes of packet data
-*pkt - packet structure to store values
-offset - integer offset indicating at what byte each header starts
-
-Returns: void
-*/
-void parse_ipv4_header(const u_char *packet, packet_t *pkt, int offset);
-void parse_ipv6_header(const u_char *packet, packet_t *pkt, int offset);
-void parse_arp_header(const u_char *packet, packet_t *pkt, int offset);
-void parse_tcp_header(const u_char *packet, packet_t *pkt, int offset);
-void parse_udp_header(const u_char *packet, packet_t *pkt, int offset);
-void parse_icmp_header(const u_char *packet, packet_t *pkt, int offset);
-
-/*
 Function: void packetParser(const u_char *packet, int packet_len, rule_t *rule)
 
 Parameters:


### PR DESCRIPTION
Inside parser.c, all of the "parse_*_header" functions were both parsing AND printing. I split the functions into separate parsing and printing functions to adhere to single responsibility principle